### PR TITLE
feat: Implement schedule command and lesson model

### DIFF
--- a/src/main/java/keycontacts/logic/Logic.java
+++ b/src/main/java/keycontacts/logic/Logic.java
@@ -35,7 +35,7 @@ public interface Logic {
     ObservableList<Student> getFilteredStudentList();
 
     /**
-     * Returns the user prefs' address book file path.
+     * Returns the user prefs' student directory file path.
      */
     Path getStudentDirectoryFilePath();
 

--- a/src/main/java/keycontacts/logic/commands/EditCommand.java
+++ b/src/main/java/keycontacts/logic/commands/EditCommand.java
@@ -48,7 +48,7 @@ public class EditCommand extends Command {
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_STUDENT_SUCCESS = "Edited Student: %1$s";
+    public static final String MESSAGE_EDIT_STUDENT_SUCCESS = "Edited student: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_STUDENT = "This student already exists in the student directory.";
 
@@ -77,7 +77,7 @@ public class EditCommand extends Command {
         }
 
         Student studentToEdit = lastShownList.get(index.getZeroBased());
-        Student editedStudent = createEditedStudent(studentToEdit, editStudentDescriptor);
+        Student editedStudent = studentToEdit.withEditStudentDescriptor(editStudentDescriptor);
 
         if (!studentToEdit.isSameStudent(editedStudent) && model.hasStudent(editedStudent)) {
             throw new CommandException(MESSAGE_DUPLICATE_STUDENT);
@@ -88,21 +88,6 @@ public class EditCommand extends Command {
         return new CommandResult(String.format(MESSAGE_EDIT_STUDENT_SUCCESS, Messages.format(editedStudent)));
     }
 
-    /**
-     * Creates and returns a {@code Student} with the details of {@code studentToEdit}
-     * edited with {@code editStudentDescriptor}.
-     */
-    private static Student createEditedStudent(Student studentToEdit, EditStudentDescriptor editStudentDescriptor) {
-        assert studentToEdit != null;
-
-        Name updatedName = editStudentDescriptor.getName().orElse(studentToEdit.getName());
-        Phone updatedPhone = editStudentDescriptor.getPhone().orElse(studentToEdit.getPhone());
-        Email updatedEmail = editStudentDescriptor.getEmail().orElse(studentToEdit.getEmail());
-        Address updatedAddress = editStudentDescriptor.getAddress().orElse(studentToEdit.getAddress());
-        Set<Tag> updatedTags = editStudentDescriptor.getTags().orElse(studentToEdit.getTags());
-
-        return new Student(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
-    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/keycontacts/logic/commands/ScheduleCommand.java
+++ b/src/main/java/keycontacts/logic/commands/ScheduleCommand.java
@@ -26,8 +26,8 @@ public class ScheduleCommand extends Command {
             + ": Schedules the regular lesson for the student identified by the index number"
             + " used in the displayed student list. This will overwrite the student's existing regular lesson,"
             + " if it exists. The scheduled lesson cannot clash with any existing lessons for other students.\n"
-            + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_DAY + "DAY"
+            + " Parameters: INDEX (must be a positive integer) "
+            + PREFIX_DAY + "DAY "
             + PREFIX_START_TIME + "START_TIME "
             + PREFIX_END_TIME + "END_TIME\n"
             + "Example: " + COMMAND_WORD + " 1 "
@@ -35,12 +35,16 @@ public class ScheduleCommand extends Command {
             + PREFIX_START_TIME + "16:00"
             + PREFIX_END_TIME + "18:00";
 
-    public static final String MESSAGE_SCHEDULE_LESSON_SUCCESS = "Scheduled lesson at $$$ for: %1$s";
+    public static final String MESSAGE_SCHEDULE_LESSON_SUCCESS = "Scheduled lesson for student: %1$s";
+    public static final String MESSAGE_LESSON_UNCHANGED = "Lesson for the student is already at that time!";
     public static final String MESSAGE_LESSON_CLASH = "There is a clashing lesson at that time!";
 
     private final Index targetIndex;
     private final RegularLesson regularLesson;
 
+    /**
+     * Creates a ScheduleCommand to schedule the given {@code regularLesson}
+     */
     public ScheduleCommand(Index targetIndex, RegularLesson regularLesson) {
         this.targetIndex = targetIndex;
         this.regularLesson = regularLesson;
@@ -56,6 +60,12 @@ public class ScheduleCommand extends Command {
         }
 
         Student studentToUpdate = lastShownList.get(targetIndex.getZeroBased());
+        Student updatedStudent = studentToUpdate.withRegularLesson(regularLesson);
+        if (studentToUpdate.equals(updatedStudent)) {
+            throw new CommandException(MESSAGE_LESSON_UNCHANGED);
+        }
+        model.setStudent(studentToUpdate, updatedStudent);
+
         return new CommandResult(String.format(MESSAGE_SCHEDULE_LESSON_SUCCESS, Messages.format(studentToUpdate)));
     }
 
@@ -70,7 +80,8 @@ public class ScheduleCommand extends Command {
             return false;
         }
 
-        return targetIndex.equals(otherScheduleCommand.targetIndex);
+        return targetIndex.equals(otherScheduleCommand.targetIndex)
+                && regularLesson.equals(otherScheduleCommand.regularLesson);
     }
 
     @Override

--- a/src/main/java/keycontacts/logic/commands/ScheduleCommand.java
+++ b/src/main/java/keycontacts/logic/commands/ScheduleCommand.java
@@ -26,7 +26,7 @@ public class ScheduleCommand extends Command {
             + ": Schedules the regular lesson for the student identified by the index number"
             + " used in the displayed student list. This will overwrite the student's existing regular lesson,"
             + " if it exists. The scheduled lesson cannot clash with any existing lessons for other students.\n"
-            + " Parameters: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_DAY + "DAY "
             + PREFIX_START_TIME + "START_TIME "
             + PREFIX_END_TIME + "END_TIME\n"

--- a/src/main/java/keycontacts/logic/commands/ScheduleCommand.java
+++ b/src/main/java/keycontacts/logic/commands/ScheduleCommand.java
@@ -1,0 +1,83 @@
+package keycontacts.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static keycontacts.logic.parser.CliSyntax.PREFIX_DAY;
+import static keycontacts.logic.parser.CliSyntax.PREFIX_END_TIME;
+import static keycontacts.logic.parser.CliSyntax.PREFIX_START_TIME;
+
+import java.util.List;
+
+import keycontacts.commons.core.index.Index;
+import keycontacts.commons.util.ToStringBuilder;
+import keycontacts.logic.Messages;
+import keycontacts.logic.commands.exceptions.CommandException;
+import keycontacts.model.Model;
+import keycontacts.model.lesson.RegularLesson;
+import keycontacts.model.student.Student;
+
+/**
+ * Schedules the regular lesson for a student identified using it's displayed index from the student directory.
+ */
+public class ScheduleCommand extends Command {
+
+    public static final String COMMAND_WORD = "schedule";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Schedules the regular lesson for the student identified by the index number"
+            + " used in the displayed student list. This will overwrite the student's existing regular lesson,"
+            + " if it exists. The scheduled lesson cannot clash with any existing lessons for other students.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_DAY + "DAY"
+            + PREFIX_START_TIME + "START_TIME "
+            + PREFIX_END_TIME + "END_TIME\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_DAY + "Monday"
+            + PREFIX_START_TIME + "16:00"
+            + PREFIX_END_TIME + "18:00";
+
+    public static final String MESSAGE_SCHEDULE_LESSON_SUCCESS = "Scheduled lesson at $$$ for: %1$s";
+    public static final String MESSAGE_LESSON_CLASH = "There is a clashing lesson at that time!";
+
+    private final Index targetIndex;
+    private final RegularLesson regularLesson;
+
+    public ScheduleCommand(Index targetIndex, RegularLesson regularLesson) {
+        this.targetIndex = targetIndex;
+        this.regularLesson = regularLesson;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Student> lastShownList = model.getFilteredStudentList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        }
+
+        Student studentToUpdate = lastShownList.get(targetIndex.getZeroBased());
+        return new CommandResult(String.format(MESSAGE_SCHEDULE_LESSON_SUCCESS, Messages.format(studentToUpdate)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ScheduleCommand otherScheduleCommand)) {
+            return false;
+        }
+
+        return targetIndex.equals(otherScheduleCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .add("regularLesson", regularLesson)
+                .toString();
+    }
+}

--- a/src/main/java/keycontacts/logic/parser/AddCommandParser.java
+++ b/src/main/java/keycontacts/logic/parser/AddCommandParser.java
@@ -8,7 +8,6 @@ import static keycontacts.logic.parser.CliSyntax.PREFIX_PHONE;
 import static keycontacts.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import keycontacts.logic.commands.AddCommand;
 import keycontacts.logic.parser.exceptions.ParseException;
@@ -33,8 +32,8 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!argMultimap.arePrefixesPresent(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
+                || argMultimap.isPreamblePresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
@@ -48,14 +47,6 @@ public class AddCommandParser implements Parser<AddCommand> {
         Student student = new Student(name, phone, email, address, tagList);
 
         return new AddCommand(student);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/keycontacts/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/keycontacts/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,18 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values, false otherwise.
+     */
+    public boolean arePrefixesPresent(Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> getValue(prefix).isPresent());
+    }
+
+    /**
+     * Returns true if the preamble is not empty, false otherwise.
+     */
+    public boolean isPreamblePresent() {
+        return !getPreamble().isEmpty();
+    }
 }

--- a/src/main/java/keycontacts/logic/parser/CliSyntax.java
+++ b/src/main/java/keycontacts/logic/parser/CliSyntax.java
@@ -11,5 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-
+    public static final Prefix PREFIX_DAY = new Prefix("d/");
+    public static final Prefix PREFIX_START_TIME = new Prefix("st/");
+    public static final Prefix PREFIX_END_TIME = new Prefix("et/");
 }

--- a/src/main/java/keycontacts/logic/parser/KeyContactsParser.java
+++ b/src/main/java/keycontacts/logic/parser/KeyContactsParser.java
@@ -17,6 +17,7 @@ import keycontacts.logic.commands.ExitCommand;
 import keycontacts.logic.commands.FindCommand;
 import keycontacts.logic.commands.HelpCommand;
 import keycontacts.logic.commands.ListCommand;
+import keycontacts.logic.commands.ScheduleCommand;
 import keycontacts.logic.parser.exceptions.ParseException;
 
 /**
@@ -51,36 +52,21 @@ public class KeyContactsParser {
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
-        switch (commandWord) {
-
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
-
-        case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
-
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
-
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
-
-        case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
-
-        case ListCommand.COMMAND_WORD:
-            return new ListCommand();
-
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
-
-        case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
-
-        default:
+        return switch (commandWord) {
+        case AddCommand.COMMAND_WORD -> new AddCommandParser().parse(arguments);
+        case EditCommand.COMMAND_WORD -> new EditCommandParser().parse(arguments);
+        case DeleteCommand.COMMAND_WORD -> new DeleteCommandParser().parse(arguments);
+        case ClearCommand.COMMAND_WORD -> new ClearCommand();
+        case FindCommand.COMMAND_WORD -> new FindCommandParser().parse(arguments);
+        case ListCommand.COMMAND_WORD -> new ListCommand();
+        case ExitCommand.COMMAND_WORD -> new ExitCommand();
+        case HelpCommand.COMMAND_WORD -> new HelpCommand();
+        case ScheduleCommand.COMMAND_WORD -> new ScheduleCommandParser().parse(arguments);
+        default -> {
             logger.finer("This user input caused a ParseException: " + userInput);
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
+        };
     }
 
 }

--- a/src/main/java/keycontacts/logic/parser/ParserUtil.java
+++ b/src/main/java/keycontacts/logic/parser/ParserUtil.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import keycontacts.commons.core.index.Index;
 import keycontacts.commons.util.StringUtil;
 import keycontacts.logic.parser.exceptions.ParseException;
+import keycontacts.model.lesson.Day;
+import keycontacts.model.lesson.Time;
 import keycontacts.model.student.Address;
 import keycontacts.model.student.Email;
 import keycontacts.model.student.Name;
@@ -93,6 +95,36 @@ public class ParserUtil {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }
         return new Email(trimmedEmail);
+    }
+
+    /**
+     * Parses a {@code String day} into a {@code Day}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code day} is invalid.
+     */
+    public static Day parseDay(String day) throws ParseException {
+        requireNonNull(day);
+        String trimmedDay = day.trim();
+        if (!Day.isValidDay(trimmedDay)) {
+            throw new ParseException(Day.MESSAGE_CONSTRAINTS);
+        }
+        return new Day(trimmedDay);
+    }
+
+    /**
+     * Parses a {@code String time} into a {@code Time}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code time} is invalid.
+     */
+    public static Time parseTime(String time) throws ParseException {
+        requireNonNull(time);
+        String trimmedTime = time.trim();
+        if (!Time.isValidTime(trimmedTime)) {
+            throw new ParseException(Time.MESSAGE_CONSTRAINTS);
+        }
+        return new Time(trimmedTime);
     }
 
     /**

--- a/src/main/java/keycontacts/logic/parser/ScheduleCommandParser.java
+++ b/src/main/java/keycontacts/logic/parser/ScheduleCommandParser.java
@@ -1,0 +1,47 @@
+package keycontacts.logic.parser;
+
+import static keycontacts.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static keycontacts.logic.parser.CliSyntax.PREFIX_DAY;
+import static keycontacts.logic.parser.CliSyntax.PREFIX_END_TIME;
+import static keycontacts.logic.parser.CliSyntax.PREFIX_START_TIME;
+
+import keycontacts.commons.core.index.Index;
+import keycontacts.logic.commands.ScheduleCommand;
+import keycontacts.logic.parser.exceptions.ParseException;
+import keycontacts.model.lesson.Day;
+import keycontacts.model.lesson.RegularLesson;
+import keycontacts.model.lesson.Time;
+
+public class ScheduleCommandParser {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ScheduleCommand
+     * and returns a ScheduleCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ScheduleCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_DAY, PREFIX_START_TIME, PREFIX_END_TIME);
+
+        if (argMultimap.arePrefixesPresent(PREFIX_DAY, PREFIX_START_TIME, PREFIX_END_TIME)
+                || !argMultimap.isPreamblePresent()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScheduleCommand.MESSAGE_USAGE));
+        }
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScheduleCommand.MESSAGE_USAGE), pe);
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor( PREFIX_DAY, PREFIX_START_TIME, PREFIX_END_TIME);
+        Day lessonDay = ParserUtil.parseDay(argMultimap.getValue(PREFIX_DAY).get());
+        Time startTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_START_TIME).get());
+        Time endTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_END_TIME).get());
+
+        RegularLesson regularLesson = new RegularLesson(lessonDay, startTime, endTime);
+
+        return new ScheduleCommand(index, regularLesson);
+    }
+
+}

--- a/src/main/java/keycontacts/logic/parser/ScheduleCommandParser.java
+++ b/src/main/java/keycontacts/logic/parser/ScheduleCommandParser.java
@@ -12,6 +12,9 @@ import keycontacts.model.lesson.Day;
 import keycontacts.model.lesson.RegularLesson;
 import keycontacts.model.lesson.Time;
 
+/**
+ * Parses input arguments and creates a new ScheduleCommand object
+ */
 public class ScheduleCommandParser {
     /**
      * Parses the given {@code String} of arguments in the context of the ScheduleCommand
@@ -22,11 +25,6 @@ public class ScheduleCommandParser {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_DAY, PREFIX_START_TIME, PREFIX_END_TIME);
 
-        if (argMultimap.arePrefixesPresent(PREFIX_DAY, PREFIX_START_TIME, PREFIX_END_TIME)
-                || !argMultimap.isPreamblePresent()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScheduleCommand.MESSAGE_USAGE));
-        }
-
         Index index;
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -34,7 +32,11 @@ public class ScheduleCommandParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScheduleCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor( PREFIX_DAY, PREFIX_START_TIME, PREFIX_END_TIME);
+        if (!argMultimap.arePrefixesPresent(PREFIX_DAY, PREFIX_START_TIME, PREFIX_END_TIME)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScheduleCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DAY, PREFIX_START_TIME, PREFIX_END_TIME);
         Day lessonDay = ParserUtil.parseDay(argMultimap.getValue(PREFIX_DAY).get());
         Time startTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_START_TIME).get());
         Time endTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_END_TIME).get());

--- a/src/main/java/keycontacts/logic/parser/ScheduleCommandParser.java
+++ b/src/main/java/keycontacts/logic/parser/ScheduleCommandParser.java
@@ -9,6 +9,7 @@ import keycontacts.commons.core.index.Index;
 import keycontacts.logic.commands.ScheduleCommand;
 import keycontacts.logic.parser.exceptions.ParseException;
 import keycontacts.model.lesson.Day;
+import keycontacts.model.lesson.Lesson;
 import keycontacts.model.lesson.RegularLesson;
 import keycontacts.model.lesson.Time;
 
@@ -41,6 +42,9 @@ public class ScheduleCommandParser {
         Time startTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_START_TIME).get());
         Time endTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_END_TIME).get());
 
+        if (!Lesson.isValidTimePair(startTime, endTime)) {
+            throw new ParseException(Lesson.MESSAGE_CONSTRAINTS);
+        }
         RegularLesson regularLesson = new RegularLesson(lessonDay, startTime, endTime);
 
         return new ScheduleCommand(index, regularLesson);

--- a/src/main/java/keycontacts/model/ModelManager.java
+++ b/src/main/java/keycontacts/model/ModelManager.java
@@ -14,7 +14,7 @@ import keycontacts.commons.core.LogsCenter;
 import keycontacts.model.student.Student;
 
 /**
- * Represents the in-memory model of the address book data.
+ * Represents the in-memory model of the student directory data.
  */
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);

--- a/src/main/java/keycontacts/model/StudentDirectory.java
+++ b/src/main/java/keycontacts/model/StudentDirectory.java
@@ -60,7 +60,7 @@ public class StudentDirectory implements ReadOnlyStudentDirectory {
     //// student-level operations
 
     /**
-     * Returns true if a student with the same identity as {@code student} exists in the address book.
+     * Returns true if a student with the same identity as {@code student} exists in the student directory.
      */
     public boolean hasStudent(Student student) {
         requireNonNull(student);
@@ -68,8 +68,8 @@ public class StudentDirectory implements ReadOnlyStudentDirectory {
     }
 
     /**
-     * Adds a student to the address book.
-     * The student must not already exist in the address book.
+     * Adds a student to the student directory.
+     * The student must not already exist in the student directory.
      */
     public void addStudent(Student p) {
         students.add(p);
@@ -77,9 +77,9 @@ public class StudentDirectory implements ReadOnlyStudentDirectory {
 
     /**
      * Replaces the given student {@code target} in the list with {@code editedStudent}.
-     * {@code target} must exist in the address book.
+     * {@code target} must exist in the student directory.
      * The student identity of {@code editedStudent} must not be the same as another
-     * existing student in the address book.
+     * existing student in the student directory.
      */
     public void setStudent(Student target, Student editedStudent) {
         requireNonNull(editedStudent);
@@ -89,7 +89,7 @@ public class StudentDirectory implements ReadOnlyStudentDirectory {
 
     /**
      * Removes {@code key} from this {@code StudentDirectory}.
-     * {@code key} must exist in the address book.
+     * {@code key} must exist in the student directory.
      */
     public void removeStudent(Student key) {
         students.remove(key);

--- a/src/main/java/keycontacts/model/lesson/Day.java
+++ b/src/main/java/keycontacts/model/lesson/Day.java
@@ -1,0 +1,91 @@
+package keycontacts.model.lesson;
+
+import static java.util.Objects.requireNonNull;
+import static keycontacts.commons.util.AppUtil.checkArgument;
+
+import java.time.DayOfWeek;
+import java.util.Map;
+
+/**
+ * Represents a Student's lesson day in the student directory.
+ * Guarantees: immutable; is valid as declared in {@link #isValidDay(String)}
+ */
+public class Day {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Days should be one of the days of the week (e.g. Monday, Tuesday etc.), or its common three letter" +
+                    " abbreviation (e.g. Mon, Tue etc.)";
+
+    /*
+     * Either day of the week, or three letter abbreviation, case-insensitive.
+     */
+    public static final String VALIDATION_REGEX =
+            "(?i)^(mon|tue|wed|thu|fri|sat|sun|monday|tuesday|wednesday|thursday|friday|saturday|sunday)$";
+
+    // Map abbreviations to full day names
+    private static final Map<String, String> ABBREVIATION_TO_DAY_MAP = Map.of(
+            "mon", "MONDAY",
+            "tue", "TUESDAY",
+            "wed", "WEDNESDAY",
+            "thu", "THURSDAY",
+            "fri", "FRIDAY",
+            "sat", "SATURDAY",
+            "sun", "SUNDAY"
+    );
+
+    private final DayOfWeek day;
+
+    /**
+     * Constructs a {@code Day}.
+     *
+     * @param day A valid day.
+     */
+    public Day(String day) {
+        requireNonNull(day);
+        checkArgument(isValidDay(day), MESSAGE_CONSTRAINTS);
+        this.day = convertToDayOfWeek(day);
+    }
+
+    /**
+     * Converts the day input into a {@link DayOfWeek} enum.
+     */
+    private DayOfWeek convertToDayOfWeek(String day) {
+        String lowerCaseDay = day.toLowerCase();
+        String fullDay = ABBREVIATION_TO_DAY_MAP.getOrDefault(lowerCaseDay, lowerCaseDay.toLowerCase());
+        return DayOfWeek.valueOf(fullDay);
+    }
+
+    /**
+     * Returns true if a given string is a valid day.
+     */
+    public static boolean isValidDay(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return day.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Day)) {
+            return false;
+        }
+
+        Day otherDay = (Day) other;
+        return day.equals(otherDay.day);
+    }
+
+    @Override
+    public int hashCode() {
+        return day.hashCode();
+    }
+
+}

--- a/src/main/java/keycontacts/model/lesson/Day.java
+++ b/src/main/java/keycontacts/model/lesson/Day.java
@@ -13,8 +13,8 @@ import java.util.Map;
 public class Day {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Days should be one of the days of the week (e.g. Monday, Tuesday etc.), or its common three letter" +
-                    " abbreviation (e.g. Mon, Tue etc.)";
+            "Days should be one of the days of the week (e.g. Monday, Tuesday etc.), or its common three letter"
+                    + " abbreviation (e.g. Mon, Tue etc.)";
 
     /*
      * Either day of the week, or three letter abbreviation, case-insensitive.
@@ -52,7 +52,7 @@ public class Day {
     private DayOfWeek convertToDayOfWeek(String day) {
         String lowerCaseDay = day.toLowerCase();
         String fullDay = ABBREVIATION_TO_DAY_MAP.getOrDefault(lowerCaseDay, lowerCaseDay.toLowerCase());
-        return DayOfWeek.valueOf(fullDay);
+        return DayOfWeek.valueOf(fullDay.toUpperCase());
     }
 
     /**

--- a/src/main/java/keycontacts/model/lesson/Lesson.java
+++ b/src/main/java/keycontacts/model/lesson/Lesson.java
@@ -1,0 +1,49 @@
+package keycontacts.model.lesson;
+
+import static keycontacts.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Objects;
+
+import keycontacts.commons.util.ToStringBuilder;
+
+/**
+ * Abstract class representing a Student's lesson in the student directory.
+ * Guarantees: immutable, has a start time and end time are valid as declared in
+ * {@link keycontacts.model.lesson.Time#isValidTime(String)}.
+ */
+public abstract class Lesson {
+
+    private final Time startTime;
+    private final Time endTime;
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Lesson(Time startTime, Time endTime) {
+        requireAllNonNull(startTime, endTime);
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public Time getStartTime() {
+        return startTime;
+    }
+
+    public Time getEndTime() {
+        return endTime;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(startTime, endTime);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("startTime", startTime)
+                .add("endTime", endTime)
+                .toString();
+    }
+
+}

--- a/src/main/java/keycontacts/model/lesson/Lesson.java
+++ b/src/main/java/keycontacts/model/lesson/Lesson.java
@@ -1,5 +1,6 @@
 package keycontacts.model.lesson;
 
+import static keycontacts.commons.util.AppUtil.checkArgument;
 import static keycontacts.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
@@ -8,10 +9,12 @@ import keycontacts.commons.util.ToStringBuilder;
 
 /**
  * Abstract class representing a Student's lesson in the student directory.
- * Guarantees: immutable, has a start time and end time are valid as declared in
- * {@link keycontacts.model.lesson.Time#isValidTime(String)}.
+ * Guarantees: immutable, start time and end time are valid as declared in
+ * {@link #isValidTimePair(Time, Time)}.
  */
 public abstract class Lesson {
+
+    public static final String MESSAGE_CONSTRAINTS = "Start time should be before end time";
 
     private final Time startTime;
     private final Time endTime;
@@ -21,8 +24,13 @@ public abstract class Lesson {
      */
     public Lesson(Time startTime, Time endTime) {
         requireAllNonNull(startTime, endTime);
+        checkArgument(isValidTimePair(startTime, endTime), MESSAGE_CONSTRAINTS);
         this.startTime = startTime;
         this.endTime = endTime;
+    }
+
+    public static boolean isValidTimePair(Time startTime, Time endTime) {
+        return startTime.getTime().isBefore(endTime.getTime());
     }
 
     public Time getStartTime() {

--- a/src/main/java/keycontacts/model/lesson/Lesson.java
+++ b/src/main/java/keycontacts/model/lesson/Lesson.java
@@ -39,6 +39,21 @@ public abstract class Lesson {
     }
 
     @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Lesson)) {
+            return false;
+        }
+
+        Lesson otherLesson = (Lesson) other;
+        return startTime.equals(otherLesson.startTime) && endTime.equals(otherLesson.endTime);
+    }
+
+    @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("startTime", startTime)
@@ -46,4 +61,10 @@ public abstract class Lesson {
                 .toString();
     }
 
+    /**
+     * Returns a user-friendly display message of the lesson.
+     */
+    public String toDisplay() {
+        return startTime.toString() + " - " + endTime.toString();
+    }
 }

--- a/src/main/java/keycontacts/model/lesson/RegularLesson.java
+++ b/src/main/java/keycontacts/model/lesson/RegularLesson.java
@@ -1,5 +1,7 @@
 package keycontacts.model.lesson;
 
+import static keycontacts.commons.util.CollectionUtil.requireAllNonNull;
+
 import java.util.Objects;
 
 import keycontacts.commons.util.ToStringBuilder;
@@ -12,16 +14,41 @@ import keycontacts.commons.util.ToStringBuilder;
  */
 public class RegularLesson extends Lesson {
 
+    public static final RegularLesson DEFAULT_REGULAR_LESSON = null;
+
     private final Day lessonDay;
 
+    /**
+     * Every field must be present and not null.
+     */
     public RegularLesson(Day lessonDay, Time startTime, Time endTime) {
         super(startTime, endTime);
+        requireAllNonNull(lessonDay);
         this.lessonDay = lessonDay;
+    }
+
+    public Day getLessonDay() {
+        return lessonDay;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(lessonDay, getStartTime(), getEndTime());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RegularLesson)) {
+            return false;
+        }
+
+        RegularLesson otherLesson = (RegularLesson) other;
+        return super.equals(otherLesson) && lessonDay.equals(otherLesson.lessonDay);
     }
 
     @Override
@@ -31,5 +58,11 @@ public class RegularLesson extends Lesson {
                 .add("startTime", getStartTime())
                 .add("endTime", getEndTime())
                 .toString();
+    }
+
+    @Override
+    public String toDisplay() {
+        return lessonDay.toString().substring(0, 1).toUpperCase()
+                + lessonDay.toString().substring(1).toLowerCase() + ", " + super.toDisplay();
     }
 }

--- a/src/main/java/keycontacts/model/lesson/RegularLesson.java
+++ b/src/main/java/keycontacts/model/lesson/RegularLesson.java
@@ -1,0 +1,35 @@
+package keycontacts.model.lesson;
+
+import java.util.Objects;
+
+import keycontacts.commons.util.ToStringBuilder;
+
+/**
+ * Abstract class representing a Student's lesson in the student directory.
+ * Guarantees: immutable, start time and end time are valid as declared in
+ * {@link keycontacts.model.lesson.Time#isValidTime(String)}, lesson day is valid as declared in
+ * {@link keycontacts.model.lesson.Day#isValidDay(String)}.
+ */
+public class RegularLesson extends Lesson {
+
+    private final Day lessonDay;
+
+    public RegularLesson(Day lessonDay, Time startTime, Time endTime) {
+        super(startTime, endTime);
+        this.lessonDay = lessonDay;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lessonDay, getStartTime(), getEndTime());
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("lessonDay", lessonDay)
+                .add("startTime", getStartTime())
+                .add("endTime", getEndTime())
+                .toString();
+    }
+}

--- a/src/main/java/keycontacts/model/lesson/RegularLesson.java
+++ b/src/main/java/keycontacts/model/lesson/RegularLesson.java
@@ -14,8 +14,6 @@ import keycontacts.commons.util.ToStringBuilder;
  */
 public class RegularLesson extends Lesson {
 
-    public static final RegularLesson DEFAULT_REGULAR_LESSON = null;
-
     private final Day lessonDay;
 
     /**

--- a/src/main/java/keycontacts/model/lesson/Time.java
+++ b/src/main/java/keycontacts/model/lesson/Time.java
@@ -13,12 +13,12 @@ import java.time.format.DateTimeFormatter;
 public class Time {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Lesson time should be in 24 hour format (e.g. 1600)";
+            "Lesson time should be in 24 hour format (e.g. 16:00)";
 
     /*
      * 24-hour time format.
      */
-    public static final String VALIDATION_REGEX = "^(?:[01]\\d|2[0-3])[0-5]\\d$";
+    public static final String VALIDATION_REGEX = "^(?:[01]\\d|2[0-3]):[0-5]\\d$";
 
     private final LocalTime time;
 
@@ -30,7 +30,7 @@ public class Time {
     public Time(String time) {
         requireNonNull(time);
         checkArgument(isValidTime(time), MESSAGE_CONSTRAINTS);
-        this.time = LocalTime.parse(time, DateTimeFormatter.ofPattern("HHmm"));
+        this.time = LocalTime.parse(time, DateTimeFormatter.ofPattern("HH:mm"));
     }
 
     /**

--- a/src/main/java/keycontacts/model/lesson/Time.java
+++ b/src/main/java/keycontacts/model/lesson/Time.java
@@ -1,0 +1,69 @@
+package keycontacts.model.lesson;
+
+import static java.util.Objects.requireNonNull;
+import static keycontacts.commons.util.AppUtil.checkArgument;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Represents a Student's lesson time in the student directory.
+ * Guarantees: immutable; is valid as declared in {@link #isValidTime(String)}
+ */
+public class Time {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Lesson time should be in 24 hour format (e.g. 1600)";
+
+    /*
+     * 24-hour time format.
+     */
+    public static final String VALIDATION_REGEX = "^(?:[01]\\d|2[0-3])[0-5]\\d$";
+
+    private final LocalTime time;
+
+    /**
+     * Constructs a {@code Time}.
+     *
+     * @param time A valid time.
+     */
+    public Time(String time) {
+        requireNonNull(time);
+        checkArgument(isValidTime(time), MESSAGE_CONSTRAINTS);
+        this.time = LocalTime.parse(time, DateTimeFormatter.ofPattern("HHmm"));
+    }
+
+    /**
+     * Returns true if a given string is a valid time.
+     */
+    public static boolean isValidTime(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return time.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Time)) {
+            return false;
+        }
+
+        Time otherTime = (Time) other;
+        return time.equals(otherTime.time);
+    }
+
+    @Override
+    public int hashCode() {
+        return time.hashCode();
+    }
+
+}

--- a/src/main/java/keycontacts/model/lesson/Time.java
+++ b/src/main/java/keycontacts/model/lesson/Time.java
@@ -40,6 +40,9 @@ public class Time {
         return test.matches(VALIDATION_REGEX);
     }
 
+    public LocalTime getTime() {
+        return time;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/keycontacts/model/student/Address.java
+++ b/src/main/java/keycontacts/model/student/Address.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static keycontacts.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Student's address in the address book.
+ * Represents a Student's address in the student directory.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
  */
 public class Address {

--- a/src/main/java/keycontacts/model/student/Email.java
+++ b/src/main/java/keycontacts/model/student/Email.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static keycontacts.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Student's email in the address book.
+ * Represents a Student's email in the student directory.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
 public class Email {

--- a/src/main/java/keycontacts/model/student/Name.java
+++ b/src/main/java/keycontacts/model/student/Name.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static keycontacts.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Student's name in the address book.
+ * Represents a Student's name in the student directory.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class Name {

--- a/src/main/java/keycontacts/model/student/Phone.java
+++ b/src/main/java/keycontacts/model/student/Phone.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static keycontacts.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Student's phone number in the address book.
+ * Represents a Student's phone number in the student directory.
  * Guarantees: immutable; is valid as declared in {@link #isValidPhone(String)}
  */
 public class Phone {

--- a/src/main/java/keycontacts/model/student/Student.java
+++ b/src/main/java/keycontacts/model/student/Student.java
@@ -32,7 +32,7 @@ public class Student {
     private final RegularLesson regularLesson;
 
     /**
-     * Constructor for a new student. Uses default student associations.
+     * Constructor for a new student. Uses default associations.
      * Every field must be present and not null.
      */
     public Student(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
@@ -42,7 +42,7 @@ public class Student {
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
-        this.regularLesson = RegularLesson.DEFAULT_REGULAR_LESSON;
+        this.regularLesson = null;
     }
 
     /**

--- a/src/main/java/keycontacts/model/student/Student.java
+++ b/src/main/java/keycontacts/model/student/Student.java
@@ -8,11 +8,12 @@ import java.util.Objects;
 import java.util.Set;
 
 import keycontacts.commons.util.ToStringBuilder;
+import keycontacts.model.lesson.RegularLesson;
 import keycontacts.model.tag.Tag;
 
 /**
- * Represents a Student in the address book.
- * Guarantees: details are present and not null, field values are validated, immutable.
+ * Represents a Student in the student directory.
+ * Guarantees: details are present and not null (except for optional fields), field values are validated, immutable.
  */
 public class Student {
 
@@ -24,6 +25,9 @@ public class Student {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+
+    // Optional fields (can be null)
+    private final RegularLesson regularLesson;
 
     /**
      * Every field must be present and not null.

--- a/src/main/java/keycontacts/model/student/Student.java
+++ b/src/main/java/keycontacts/model/student/Student.java
@@ -5,15 +5,17 @@ import static keycontacts.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import keycontacts.commons.util.ToStringBuilder;
+import keycontacts.logic.commands.EditCommand.EditStudentDescriptor;
 import keycontacts.model.lesson.RegularLesson;
 import keycontacts.model.tag.Tag;
 
 /**
  * Represents a Student in the student directory.
- * Guarantees: details are present and not null (except for optional fields), field values are validated, immutable.
+ * Guarantees: details are present, field values are validated, immutable
  */
 public class Student {
 
@@ -26,10 +28,11 @@ public class Student {
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
 
-    // Optional fields (can be null)
+    // Associations
     private final RegularLesson regularLesson;
 
     /**
+     * Constructor for a new student. Uses default student associations.
      * Every field must be present and not null.
      */
     public Student(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
@@ -39,6 +42,22 @@ public class Student {
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+        this.regularLesson = RegularLesson.DEFAULT_REGULAR_LESSON;
+    }
+
+    /**
+     * Constructor for a new student with non-default student associations. Identity and data fields must be
+     * present and not null.
+     */
+    public Student(Name name, Phone phone, Email email, Address address, Set<Tag> tags,
+                    RegularLesson regularLesson) {
+        requireAllNonNull(name, phone, email, address, tags);
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.tags.addAll(tags);
+        this.regularLesson = regularLesson;
     }
 
     public Name getName() {
@@ -65,6 +84,45 @@ public class Student {
         return Collections.unmodifiableSet(tags);
     }
 
+    public Optional<RegularLesson> getRegularLesson() {
+        return Optional.ofNullable(regularLesson);
+    }
+
+    /**
+     * Returns string representation of the {@code regularLesson}
+     */
+    public String getRegularLessonString() {
+        return Optional.ofNullable(regularLesson).map(RegularLesson::toString).orElse(null);
+    }
+
+    /**
+     * Returns user-friendly display string of the {@code regularLesson}.
+     */
+    public String getRegularLessonDisplay() {
+        return Optional.ofNullable(regularLesson).map(RegularLesson::toDisplay)
+                .orElse("No regular lesson scheduled");
+    }
+
+    /**
+     * Creates and returns a new {@code Student} with the details edited with {@code editStudentDescriptor}.
+     */
+    public Student withEditStudentDescriptor(EditStudentDescriptor editStudentDescriptor) {
+        Name updatedName = editStudentDescriptor.getName().orElse(name);
+        Phone updatedPhone = editStudentDescriptor.getPhone().orElse(phone);
+        Email updatedEmail = editStudentDescriptor.getEmail().orElse(email);
+        Address updatedAddress = editStudentDescriptor.getAddress().orElse(address);
+        Set<Tag> updatedTags = editStudentDescriptor.getTags().orElse(tags);
+
+        return new Student(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, regularLesson);
+    }
+
+    /**
+     * Creates and returns a new {@code Student} with the updated {@code regularLesson}.
+     */
+    public Student withRegularLesson(RegularLesson regularLesson) {
+        return new Student(name, phone, email, address, tags, regularLesson);
+    }
+
     /**
      * Returns true if both students have the same name.
      * This defines a weaker notion of equality between two students.
@@ -79,7 +137,7 @@ public class Student {
     }
 
     /**
-     * Returns true if both students have the same identity and data fields.
+     * Returns true if both students have the same identity, data fields and associations.
      * This defines a stronger notion of equality between two students.
      */
     @Override
@@ -98,13 +156,14 @@ public class Student {
                 && phone.equals(otherStudent.phone)
                 && email.equals(otherStudent.email)
                 && address.equals(otherStudent.address)
-                && tags.equals(otherStudent.tags);
+                && tags.equals(otherStudent.tags)
+                && getRegularLesson().equals(otherStudent.getRegularLesson());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, tags, regularLesson);
     }
 
     @Override
@@ -115,6 +174,7 @@ public class Student {
                 .add("email", email)
                 .add("address", address)
                 .add("tags", tags)
+                .add("regularLesson", regularLesson)
                 .toString();
     }
 

--- a/src/main/java/keycontacts/model/tag/Tag.java
+++ b/src/main/java/keycontacts/model/tag/Tag.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static keycontacts.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Tag in the address book.
+ * Represents a Tag in the student directory.
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
  */
 public class Tag {

--- a/src/main/java/keycontacts/storage/JsonAdaptedRegularLesson.java
+++ b/src/main/java/keycontacts/storage/JsonAdaptedRegularLesson.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import keycontacts.commons.exceptions.IllegalValueException;
 import keycontacts.model.lesson.Day;
+import keycontacts.model.lesson.Lesson;
 import keycontacts.model.lesson.RegularLesson;
 import keycontacts.model.lesson.Time;
 
@@ -63,6 +64,9 @@ class JsonAdaptedRegularLesson {
         }
         final Time modelStartTime = new Time(startTime);
         final Time modelEndTime = new Time(endTime);
+        if (!Lesson.isValidTimePair(modelStartTime, modelEndTime)) {
+            throw new IllegalValueException(Lesson.MESSAGE_CONSTRAINTS);
+        }
 
         return new RegularLesson(modelLessonDay, modelStartTime, modelEndTime);
     }

--- a/src/main/java/keycontacts/storage/JsonAdaptedRegularLesson.java
+++ b/src/main/java/keycontacts/storage/JsonAdaptedRegularLesson.java
@@ -1,0 +1,70 @@
+package keycontacts.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import keycontacts.commons.exceptions.IllegalValueException;
+import keycontacts.model.lesson.Day;
+import keycontacts.model.lesson.RegularLesson;
+import keycontacts.model.lesson.Time;
+
+/**
+ * Jackson-friendly version of {@link RegularLesson}.
+ */
+class JsonAdaptedRegularLesson {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Regular lesson's %s field is missing!";
+
+    private final String lessonDay;
+    private final String startTime;
+    private final String endTime;
+
+    /**
+     * Constructs a {@code JsonAdaptedRegularLesson} with the given student association details.
+     */
+    @JsonCreator
+    public JsonAdaptedRegularLesson(@JsonProperty("lessonDay") String lessonDay,
+                                    @JsonProperty("startTime") String startTime,
+                                    @JsonProperty("endTime") String endTime) {
+        this.lessonDay = lessonDay;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    /**
+     * Converts a given {@code RegularLesson} into this class for Jackson use.
+     */
+    public JsonAdaptedRegularLesson(RegularLesson source) {
+        lessonDay = source.getLessonDay().toString();
+        startTime = source.getStartTime().toString();
+        endTime = source.getEndTime().toString();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted regular lesson object into the model's {@code RegularLesson} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted regular lesson.
+     */
+    public RegularLesson toModelType() throws IllegalValueException {
+
+        if (lessonDay == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Day.class.getSimpleName()));
+        }
+        if (!Day.isValidDay(lessonDay)) {
+            throw new IllegalValueException(Day.MESSAGE_CONSTRAINTS);
+        }
+        final Day modelLessonDay = new Day(lessonDay);
+
+        if (startTime == null || endTime == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Time.class.getSimpleName()));
+        }
+        if (!Time.isValidTime(startTime) || !Time.isValidTime(endTime)) {
+            throw new IllegalValueException(Time.MESSAGE_CONSTRAINTS);
+        }
+        final Time modelStartTime = new Time(startTime);
+        final Time modelEndTime = new Time(endTime);
+
+        return new RegularLesson(modelLessonDay, modelStartTime, modelEndTime);
+    }
+
+}

--- a/src/main/java/keycontacts/storage/JsonAdaptedStudent.java
+++ b/src/main/java/keycontacts/storage/JsonAdaptedStudent.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import keycontacts.commons.exceptions.IllegalValueException;
+import keycontacts.model.lesson.RegularLesson;
 import keycontacts.model.student.Address;
 import keycontacts.model.student.Email;
 import keycontacts.model.student.Name;
@@ -29,6 +30,7 @@ class JsonAdaptedStudent {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
+    private final JsonAdaptedRegularLesson regularLesson;
 
     /**
      * Constructs a {@code JsonAdaptedStudent} with the given student details.
@@ -36,7 +38,8 @@ class JsonAdaptedStudent {
     @JsonCreator
     public JsonAdaptedStudent(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+            @JsonProperty("tags") List<JsonAdaptedTag> tags,
+            @JsonProperty("regularLesson") JsonAdaptedRegularLesson regularLesson) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -44,6 +47,7 @@ class JsonAdaptedStudent {
         if (tags != null) {
             this.tags.addAll(tags);
         }
+        this.regularLesson = regularLesson;
     }
 
     /**
@@ -57,6 +61,7 @@ class JsonAdaptedStudent {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        regularLesson = source.getRegularLesson().map(JsonAdaptedRegularLesson::new).orElse(null);
     }
 
     /**
@@ -103,7 +108,15 @@ class JsonAdaptedStudent {
         final Address modelAddress = new Address(address);
 
         final Set<Tag> modelTags = new HashSet<>(studentTags);
-        return new Student(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+
+        final RegularLesson modelRegularLesson;
+        if (regularLesson != null) {
+            modelRegularLesson = regularLesson.toModelType();
+        } else {
+            modelRegularLesson = null;
+        }
+
+        return new Student(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelRegularLesson);
     }
 
 }

--- a/src/main/java/keycontacts/ui/StudentCard.java
+++ b/src/main/java/keycontacts/ui/StudentCard.java
@@ -39,6 +39,8 @@ public class StudentCard extends UiPart<Region> {
     @FXML
     private Label email;
     @FXML
+    private Label regularLesson;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -52,6 +54,7 @@ public class StudentCard extends UiPart<Region> {
         phone.setText(student.getPhone().value);
         address.setText(student.getAddress().value);
         email.setText(student.getEmail().value);
+        regularLesson.setText(student.getRegularLessonDisplay());
         student.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -30,6 +30,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="regularLesson" styleClass="cell_small_label" text="\$regularLesson" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/keycontacts/model/student/StudentTest.java
+++ b/src/test/java/keycontacts/model/student/StudentTest.java
@@ -93,7 +93,8 @@ public class StudentTest {
     @Test
     public void toStringMethod() {
         String expected = Student.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + "}";
+                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags()
+                + ", regularLesson=" + ALICE.getRegularLessonString() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/keycontacts/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/keycontacts/storage/JsonAdaptedStudentTest.java
@@ -32,7 +32,7 @@ public class JsonAdaptedStudentTest {
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
 
-    private static final JsonAdaptedRegularLesson DEFAULT_REGULAR_LESSON = null;
+    private static final JsonAdaptedRegularLesson EMPTY_REGULAR_LESSON = null;
 
     @Test
     public void toModelType_validStudentDetails_returnsStudent() throws Exception {
@@ -44,7 +44,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        DEFAULT_REGULAR_LESSON);
+                        EMPTY_REGULAR_LESSON);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -52,7 +52,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS, DEFAULT_REGULAR_LESSON);
+                VALID_TAGS, EMPTY_REGULAR_LESSON);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -61,7 +61,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        DEFAULT_REGULAR_LESSON);
+                        EMPTY_REGULAR_LESSON);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -69,7 +69,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                DEFAULT_REGULAR_LESSON);
+                EMPTY_REGULAR_LESSON);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -77,7 +77,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS, DEFAULT_REGULAR_LESSON);
+                VALID_TAGS, EMPTY_REGULAR_LESSON);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -85,7 +85,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_TAGS, DEFAULT_REGULAR_LESSON);
+                VALID_TAGS, EMPTY_REGULAR_LESSON);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -94,7 +94,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS,
-                        DEFAULT_REGULAR_LESSON);
+                        EMPTY_REGULAR_LESSON);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -102,7 +102,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS,
-                DEFAULT_REGULAR_LESSON);
+                EMPTY_REGULAR_LESSON);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -112,7 +112,7 @@ public class JsonAdaptedStudentTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                invalidTags, DEFAULT_REGULAR_LESSON);
+                invalidTags, EMPTY_REGULAR_LESSON);
         assertThrows(IllegalValueException.class, student::toModelType);
     }
 

--- a/src/test/java/keycontacts/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/keycontacts/storage/JsonAdaptedStudentTest.java
@@ -32,6 +32,8 @@ public class JsonAdaptedStudentTest {
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
 
+    private static final JsonAdaptedRegularLesson DEFAULT_REGULAR_LESSON = null;
+
     @Test
     public void toModelType_validStudentDetails_returnsStudent() throws Exception {
         JsonAdaptedStudent student = new JsonAdaptedStudent(BENSON);
@@ -41,14 +43,16 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                        DEFAULT_REGULAR_LESSON);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TAGS, DEFAULT_REGULAR_LESSON);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -56,29 +60,32 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                        DEFAULT_REGULAR_LESSON);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                DEFAULT_REGULAR_LESSON);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
-        JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
+                VALID_TAGS, DEFAULT_REGULAR_LESSON);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
+                VALID_TAGS, DEFAULT_REGULAR_LESSON);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -86,14 +93,16 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS,
+                        DEFAULT_REGULAR_LESSON);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS,
+                DEFAULT_REGULAR_LESSON);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -102,8 +111,8 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                invalidTags, DEFAULT_REGULAR_LESSON);
         assertThrows(IllegalValueException.class, student::toModelType);
     }
 


### PR DESCRIPTION
Closes #20 

This PR

- Implements `schedule` command to allow scheduling of student's regular lessons
- Implements the `Lesson` and `RegularLesson` classes. This can be built on for the implementation of the `AdhocLesson` class

Notes:

- UG and tests have not been updated, this will be done in v1.3