### PR TITLE
Add tests to grade level field

### DIFF
--- a/src/test/java/keycontacts/model/student/GradeLevelTest.java
+++ b/src/test/java/keycontacts/model/student/GradeLevelTest.java
@@ -53,5 +53,8 @@ public class GradeLevelTest {
 
         // different values -> returns false
         assertFalse(gradeLevel.equals(new GradeLevel("Trinity 1")));
+
+        // same exam board, different grade -> returns false
+        assertFalse(gradeLevel.equals(new GradeLevel("ABRSM 2")));
     }
 }

--- a/src/test/java/keycontacts/model/student/GradeLevelTest.java
+++ b/src/test/java/keycontacts/model/student/GradeLevelTest.java
@@ -1,0 +1,56 @@
+package keycontacts.model.student;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class GradeLevelTest {
+    
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new GradeLevel(null));
+    }
+
+    @Test
+    public void constructor_invalidGradeLevel_throwsIllegalArgumentException() {
+        String invalidGradeLevel = ""; //empty string
+        assertThrows(IllegalArgumentException.class, () -> new GradeLevel(invalidGradeLevel));
+    }
+
+    @Test
+    public void is_valid_grade_level() {
+        // valid grade levels
+        assertTrue(GradeLevel.isValidGradeLevel("ABRSM 1"));
+        assertTrue(GradeLevel.isValidGradeLevel("Trinity 1"));
+        assertTrue(GradeLevel.isValidGradeLevel("RSL 2"));
+        assertTrue(GradeLevel.isValidGradeLevel("LCM 3"));
+        assertTrue(GradeLevel.isValidGradeLevel("AMEB 4"));
+
+        // invalid grade levels
+        // special character
+        assertTrue(GradeLevel.isValidGradeLevel("ABRSM 1!"));
+        // no space
+        assertTrue(GradeLevel.isValidGradeLevel("Trinity1"));
+    }
+
+    @Test
+    public void equals() {
+        GradeLevel gradeLevel = new GradeLevel("ABRSM 1");
+
+        // same values -> returns true
+        assertTrue(gradeLevel.equals(new GradeLevel("ABRSM 1")));
+
+        // same object -> returns true
+        assertTrue(gradeLevel.equals(gradeLevel));
+
+        // null -> returns false
+        assertTrue(gradeLevel.equals(null));
+
+        // different types -> returns false
+        assertTrue(gradeLevel.equals(5.0f));
+
+        // different values -> returns false
+        assertTrue(gradeLevel.equals(new GradeLevel("Trinity 1")));
+    }
+}

--- a/src/test/java/keycontacts/model/student/GradeLevelTest.java
+++ b/src/test/java/keycontacts/model/student/GradeLevelTest.java
@@ -1,12 +1,13 @@
 package keycontacts.model.student;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 public class GradeLevelTest {
-    
+
     @Test
     public void constructor_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new GradeLevel(null));
@@ -19,7 +20,7 @@ public class GradeLevelTest {
     }
 
     @Test
-    public void is_valid_grade_level() {
+    public void isValidGradeLevel() {
         // valid grade levels
         assertTrue(GradeLevel.isValidGradeLevel("ABRSM 1"));
         assertTrue(GradeLevel.isValidGradeLevel("Trinity 1"));
@@ -29,9 +30,9 @@ public class GradeLevelTest {
 
         // invalid grade levels
         // special character
-        assertTrue(GradeLevel.isValidGradeLevel("ABRSM 1!"));
+        assertFalse(GradeLevel.isValidGradeLevel("ABRSM 1!"));
         // no space
-        assertTrue(GradeLevel.isValidGradeLevel("Trinity1"));
+        assertFalse(GradeLevel.isValidGradeLevel("Trinity1"));
     }
 
     @Test
@@ -45,12 +46,12 @@ public class GradeLevelTest {
         assertTrue(gradeLevel.equals(gradeLevel));
 
         // null -> returns false
-        assertTrue(gradeLevel.equals(null));
+        assertFalse(gradeLevel.equals(null));
 
         // different types -> returns false
-        assertTrue(gradeLevel.equals(5.0f));
+        assertFalse(gradeLevel.equals(5.0f));
 
         // different values -> returns false
-        assertTrue(gradeLevel.equals(new GradeLevel("Trinity 1")));
+        assertFalse(gradeLevel.equals(new GradeLevel("Trinity 1")));
     }
 }

--- a/src/test/java/keycontacts/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/keycontacts/storage/JsonAdaptedStudentTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import keycontacts.commons.exceptions.IllegalValueException;
 import keycontacts.model.student.Address;
+import keycontacts.model.student.GradeLevel;
 import keycontacts.model.student.Name;
 import keycontacts.model.student.Phone;
 
@@ -80,6 +81,23 @@ public class JsonAdaptedStudentTest {
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_ADDRESS, VALID_GRADE_LEVEL, VALID_PIANO_PIECES,
                         EMPTY_REGULAR_LESSON);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidGradeLevel_throwsIllegalValueException() {
+        JsonAdaptedStudent student =
+                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_ADDRESS, INVALID_GRADE_LEVEL, VALID_PIANO_PIECES,
+                        EMPTY_REGULAR_LESSON);
+        String expectedMessage = GradeLevel.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullGradeLevel_throwsIllegalValueException() {
+        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_ADDRESS, null,
+                VALID_PIANO_PIECES, EMPTY_REGULAR_LESSON);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, GradeLevel.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 


### PR DESCRIPTION
Closes #96

The unit test suite does not have dedicated test to verify expected behavior or grade level field.

No such test coverage of grade level field could cause unexpected misbehavior or bugs in the future when the codebase is updated in the future.

Add tests to grade level field to ensure that the grade level field to ensure that the grade level field is working as expected.

Let's add tests to grade level field to ensure that the grade level field is working as expected.