### PR TITLE
Enable grade level to take multiple digit number

### DIFF
--- a/src/main/java/keycontacts/model/student/GradeLevel.java
+++ b/src/main/java/keycontacts/model/student/GradeLevel.java
@@ -70,6 +70,6 @@ public class GradeLevel {
      * @return
      */
     public static boolean isValidGradeLevel(String gradeLevel) {
-        return gradeLevel.matches("^[a-zA-Z0-9 ]{1,50} [1-9]|1[0-2]$");
+        return gradeLevel.matches("^[a-zA-Z0-9 ]{1,50} \\d+$");
     }
 }

--- a/src/test/java/keycontacts/model/student/GradeLevelTest.java
+++ b/src/test/java/keycontacts/model/student/GradeLevelTest.java
@@ -27,6 +27,7 @@ public class GradeLevelTest {
         assertTrue(GradeLevel.isValidGradeLevel("RSL 2"));
         assertTrue(GradeLevel.isValidGradeLevel("LCM 3"));
         assertTrue(GradeLevel.isValidGradeLevel("AMEB 4"));
+        assertTrue(GradeLevel.isValidGradeLevel("AMEB 15"));
 
         // invalid grade levels
         // special character


### PR DESCRIPTION
Closes #122 

The program does not allow user to take multiple digit number for grade level.

However, some music examination board can take more than a decade to finish in the worst case. Thus, it is important to allow the program to take multiple digit number for grade level for the sake of flexibility.

Allow the program to take multiple digit number for grade level.

Modified Regex expression to allow multiple digit number for grade level and added test cases to test the new requirements.