### PR TITLE
Fix UI bugs

### DIFF
--- a/src/main/java/keycontacts/ui/Binder.java
+++ b/src/main/java/keycontacts/ui/Binder.java
@@ -46,7 +46,12 @@ public class Binder extends UiPart<Region> {
     private void updateArcs(double height) {
         loopParent.getChildren().clear();
 
-        int numArcs = (int) (height / (ARC_RADIUS_Y * 2 + loopParent.getSpacing())) - 5;
+        // The number of arcs that makes the difference between scene height and binder height
+        int bufferArcs = 3;
+        // For some reason, there is an extra one pixel of spacing between loops than expected
+        int extraSpacing = 1;
+
+        int numArcs = (int) (height / (ARC_RADIUS_Y * 2 + loopParent.getSpacing() + extraSpacing)) - bufferArcs;
 
         addArcs(numArcs);
     }

--- a/src/main/java/keycontacts/ui/StudentListPanel.java
+++ b/src/main/java/keycontacts/ui/StudentListPanel.java
@@ -27,6 +27,11 @@ public class StudentListPanel extends UiPart<Region> {
         super(FXML);
         studentListView.setItems(studentList);
         studentListView.setCellFactory(listView -> new StudentListViewCell());
+        studentListView.getSelectionModel().selectedItemProperty().addListener((obs, oldSelection, newSelection) -> {
+            if (newSelection != null) {
+                studentListView.scrollTo(studentListView.getSelectionModel().getSelectedIndex());
+            }
+        });
     }
 
     /**

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -112,7 +112,7 @@
 
 .result-display {
     -fx-background-color: transparent;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Segoe UI";
     -fx-font-size: 13pt;
     -fx-text-fill: white;
 }
@@ -122,7 +122,7 @@
 }
 
 .status-bar .label {
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Segoe UI";
     -fx-text-fill: white;
     -fx-padding: 4px;
     -fx-pref-height: 30px;
@@ -162,7 +162,7 @@
 
 .menu-bar .label {
     -fx-font-size: 14pt;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Segoe UI";
     -fx-text-fill: white;
     -fx-opacity: 0.9;
 }
@@ -287,7 +287,7 @@
     -fx-border-color: #383838 #383838 #ffffff #383838;
     -fx-border-insets: 0;
     -fx-border-width: 1;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Segoe UI";
     -fx-font-size: 13pt;
     -fx-text-fill: white;
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -301,6 +301,10 @@
     -fx-background-radius: 0;
 }
 
+#resultDisplay .corner {
+    -fx-background-color: transparent;
+}
+
 .group-chip {
     -fx-background-color: darkblue;
     -fx-background-radius: 20;

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,8 +40,8 @@
                                     </padding>
                                 </StackPane>
 
-                                <StackPane fx:id="resultDisplayPlaceholder" maxHeight="100" minHeight="100"
-                                           prefHeight="100" styleClass="pane-with-border" VBox.vgrow="NEVER">
+                                <StackPane fx:id="resultDisplayPlaceholder" maxHeight="130" minHeight="130"
+                                           prefHeight="130" styleClass="pane-with-border" VBox.vgrow="NEVER">
                                     <padding>
                                         <Insets bottom="5" left="10" right="10" top="5"/>
                                     </padding>


### PR DESCRIPTION
Made the following fixes:
1. Manually set the scroll bar to the selected entry to override the default action to fix #158 
2. Expand the result box to fix #150 
3. Change all instances of font family Segoe UI Light to Segoe UI to fix #148 
4. Fix the binder's scaling on very tall screens to fix #159 
5. Remove the white corner in the result display to fix #156 